### PR TITLE
feat:Add multi selection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0] - 2025-07-25
+### Added
+- Multi-Focus Support
+  - Added new methods to Tree for programmatic multi-node selection.
+  - New `AllFocused()` iterator to traverse all focused nodes.
+  - Added shift+up/down key bindings (`ExtendUp`, `ExtendDown`) for interactive range selection in terminal UI
+  - Updated renderer to highlight all focused nodes simultaneously in tree output
+  - Enhanced search functionality: `SearchAndExpand()` now focuses all directly matching nodes (not just the first match)
+### Updated
+- `Tree.GetFocusedID()` and `Tree.GetFocusedNode()` now return the primary (first) focused node to maintain API compatibility
+- `Tree.SearchAndExpand()` now highlights all matching nodes
+- `Tree.ToggleFocused()` now toggles all focused nodes
+- File browser example showcases multi-focus capabilities with an updated metadata panel during multi-focus
+
 ## [v1.0.0] - 2025-07-24
 ### Released
 - My feature-rich Go library for displaying and navigating tree structures in the terminal. 😁

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Demonstrates viewport-aware rendering for handling large tree structures\. Solve
 **[File Browser](examples/intermediate/04-file-browser/)**  
 Complete, terminal file browser application built with TreeView and Bubble Tea.
 
-<img src="https://vhs.charm.sh/vhs-6O3mmq9mImLCcoU6xZEeao.gif" alt="Demo" height="400">
+<img src="https://vhs.charm.sh/vhs-5XfivVFWrVQQODOA3d6ysd.gif" alt="Demo" height="400">
 
 ## Contributing
 

--- a/constructors.go
+++ b/constructors.go
@@ -50,18 +50,21 @@ func NewTree[T any](nodes []*Node[T], opts ...option[T]) *Tree[T] {
 // newTree creates a new Tree with the provided node's configuration.
 func newTree[T any](nodes []*Node[T], cfg *masterConfig[T]) *Tree[T] {
 	// Initialize focus to the first node if available
-	var first *Node[T]
+	var focusedNodes []*Node[T]
+	focusedIDs := make(map[string]bool)
 	if len(nodes) > 0 {
-		first = nodes[0]
+		focusedNodes = []*Node[T]{nodes[0]}
+		focusedIDs[nodes[0].ID()] = true
 	}
 
 	// Create the tree with default components
 	t := &Tree[T]{
-		nodes:    nodes,
-		focused:  first,
-		searcher: cfg.searcher,
-		focusPol: cfg.focusPol,
-		provider: cfg.provider,
+		nodes:        nodes,
+		focusedNodes: focusedNodes,
+		focusedIDs:   focusedIDs,
+		searcher:     cfg.searcher,
+		focusPol:     cfg.focusPol,
+		provider:     cfg.provider,
 	}
 	return t
 }

--- a/constructors_test.go
+++ b/constructors_test.go
@@ -37,10 +37,11 @@ func TestNewTree(t *testing.T) {
 			wantLen: 1,
 			checkFn: func(t *testing.T, tree *Tree[string]) {
 				t.Helper()
-				if tree.focused == nil {
+				focusedNode := tree.GetFocusedNode()
+				if focusedNode == nil {
 					t.Error("NewTree(single node) focused = nil, want first node")
-				} else if tree.focused.ID() != "1" {
-					t.Errorf("NewTree(single node) focused.ID() = %q, want %q", tree.focused.ID(), "1")
+				} else if focusedNode.ID() != "1" {
+					t.Errorf("NewTree(single node) focused.ID() = %q, want %q", focusedNode.ID(), "1")
 				}
 			},
 		},
@@ -54,10 +55,11 @@ func TestNewTree(t *testing.T) {
 			wantLen: 3,
 			checkFn: func(t *testing.T, tree *Tree[string]) {
 				t.Helper()
-				if tree.focused == nil {
+				focusedNode := tree.GetFocusedNode()
+				if focusedNode == nil {
 					t.Error("NewTree(multiple nodes) focused = nil, want first node")
-				} else if tree.focused.ID() != "1" {
-					t.Errorf("NewTree(multiple nodes) focused.ID() = %q, want %q", tree.focused.ID(), "1")
+				} else if focusedNode.ID() != "1" {
+					t.Errorf("NewTree(multiple nodes) focused.ID() = %q, want %q", focusedNode.ID(), "1")
 				}
 			},
 		},

--- a/examples/intermediate/04-file-browser/README.md
+++ b/examples/intermediate/04-file-browser/README.md
@@ -10,4 +10,4 @@ go run main.go
 
 ## Demo
 
-![The Demo](https://vhs.charm.sh/vhs-6O3mmq9mImLCcoU6xZEeao.gif)
+![The Demo](https://vhs.charm.sh/vhs-5XfivVFWrVQQODOA3d6ysd.gif)

--- a/examples/intermediate/04-file-browser/demo.tape
+++ b/examples/intermediate/04-file-browser/demo.tape
@@ -3,8 +3,8 @@ Output demo.gif
 Set Framerate 10
 Set Shell zsh
 Set FontSize 32
-Set Width 2000
-Set Height 800
+Set Width 2200
+Set Height 1200
 
 Type "go run main.go"
 Sleep 1s
@@ -18,20 +18,54 @@ Type "h"
 Sleep 2s
 Type "h"
 Sleep 2s
-Down 1
-Sleep 1s
-Down 1
-Sleep 1s
-Down 1
-Sleep 1s
-Down 1
-Sleep 1s
-Down 1
-Sleep 1s
-Down 1
-Sleep 1s
-Down 1
-Sleep 1s
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+Type "]"
+Sleep 250ms
+
+Sleep 5s
 Enter
 Sleep 2s
 

--- a/iterators.go
+++ b/iterators.go
@@ -42,6 +42,24 @@ func (t *Tree[T]) AllVisible(ctx context.Context) iter.Seq2[NodeInfo[T], error] 
 	}
 }
 
+// AllFocused returns an iterator over all focused nodes in the tree.
+// Context errors are returned unwrapped.
+func (t *Tree[T]) AllFocused(ctx context.Context) iter.Seq2[NodeInfo[T], error] {
+	return func(yield func(NodeInfo[T], error) bool) {
+		for info, err := range t.All(ctx) {
+			if err != nil {
+				yield(NodeInfo[T]{}, err)
+				return
+			}
+			if t.IsFocused(info.Node.ID()) {
+				if !yield(info, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
 // BreadthFirst returns an iterator over nodes using breadth first traversal.
 // Context errors are returned unwrapped.
 func (t *Tree[T]) BreadthFirst(ctx context.Context) iter.Seq2[NodeInfo[T], error] {

--- a/renderer.go
+++ b/renderer.go
@@ -82,8 +82,9 @@ func renderTree[T any](ctx context.Context, tree *Tree[T]) (string, int, error) 
 		}
 
 		// Check if this node should be highlighted as focused
-		isFocused := node.ID() == tree.GetFocusedID()
-		if isFocused {
+		isFocused := tree.IsFocused(node.ID())
+		if isFocused && focusedLineIndex == -1 {
+			// Set focused line index to the first focused node for viewport positioning
 			focusedLineIndex = lineIdx
 		}
 

--- a/tui_test.go
+++ b/tui_test.go
@@ -231,6 +231,8 @@ func TestDefaultKeyMap(t *testing.T) {
 		Down:         []string{"down"},
 		Toggle:       []string{"right", "left"},
 		Reset:        []string{"ctrl+r"},
+		ExtendUp:     []string{"shift+up"},
+		ExtendDown:   []string{"shift+down"},
 		SearchStart:  []string{"enter"},
 		SearchAccept: []string{"enter"},
 		SearchCancel: []string{"esc"},


### PR DESCRIPTION
## [v1.1.0] - 2025-07-25
### Added
- Multi-Focus Support
  - Added new methods to Tree for programmatic multi-node selection.
  - New `AllFocused()` iterator to traverse all focused nodes.
  - Added shift+up/down key bindings (`ExtendUp`, `ExtendDown`) for interactive range selection in terminal UI
  - Updated renderer to highlight all focused nodes simultaneously in tree output
  - Enhanced search functionality: `SearchAndExpand()` now focuses all directly matching nodes (not just the first match)
### Updated
- `Tree.GetFocusedID()` and `Tree.GetFocusedNode()` now return the primary (first) focused node to maintain API compatibility
- `Tree.SearchAndExpand()` now highlights all matching nodes
- `Tree.ToggleFocused()` now toggles all focused nodes
- File browser example showcases multi-focus capabilities with an updated metadata panel during multi-focus
