### PR TITLE
Extra data inside FileInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2025-07-30
+### Added
+- Ability to add arbitrary data to the `FileInfo` pre-build node type.
+- Star history to readme. 
+
 ## [v1.1.0] - 2025-07-25
 ### Added
 - Multi-Focus Support

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ TreeView is built on top of the excellent [Charm](https://charm.sh) ecosystem:
 - [VHS](https://github.com/charmbracelet/vhs) for epic scriptable demos
 - [Charm](https://github.com/charmbracelet) community for inspiration and gif hosting!
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Digital-Shane/treeview&type=Date)](https://www.star-history.com/#Digital-Shane/treeview&Date)
+
 ---
 
 [lg]: https://github.com/charmbracelet/lipgloss

--- a/node.go
+++ b/node.go
@@ -168,6 +168,7 @@ func (n *Node[T]) Parent() *Node[T] {
 type FileInfo struct {
 	os.FileInfo
 	Path string
+	Extra map[string]any
 }
 
 // NewFileSystemNode builds a FileSystemNode from a path and the corresponding


### PR DESCRIPTION
I hope to find a better solution for this in v2 (will release alongside bubbletea v2), but for now this will allow users of the FileSystem Tree constructor add arbitrary data to the nodes. 

## [v1.2.0] - 2025-07-30
### Added
- Ability to add arbitrary data to the `FileInfo` pre-build node type.
- Star history to readme. 