### PR TITLE
Significantly improve render performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.0] - 2025-08-17
+### Updated
+- Significantly improve render performance when using a viewport.
+
 ## [v1.4.1] - 2025-08-04
 ### Fixed
 - Default search function data casting

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ test:
 test-verbose:
     go test -v ./...
 
+# Run benchmarks (skip regular tests)
+bench:
+    go test -run=^$ -bench=. -benchmem ./...
+
 # Generate test coverage report and open in browser
 test-coverage:
     #!/usr/bin/env bash

--- a/renderer_bench_test.go
+++ b/renderer_bench_test.go
@@ -1,0 +1,96 @@
+package treeview
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// benchProvider is a minimal provider to minimize noise in benchmarks.
+// We implement generic methods by wrapping with a generic struct.
+type benchNodeProvider[T any] struct{}
+
+func (p *benchNodeProvider[T]) Icon(n *Node[T]) string   { return "📁" }
+func (p *benchNodeProvider[T]) Format(n *Node[T]) string { return n.Name() }
+func (p *benchNodeProvider[T]) Style(n *Node[T], focused bool) lipgloss.Style {
+	if focused {
+		return lipgloss.NewStyle().Bold(true)
+	}
+	return lipgloss.NewStyle()
+}
+
+// buildWideTree creates a root with numChildren direct leaf children.
+func buildWideTree(numChildren int) *Tree[string] {
+	root := NewNode("root", "root", "root")
+	for i := 0; i < numChildren; i++ {
+		child := NewNode(fmt.Sprintf("c%d", i), fmt.Sprintf("c%d", i), "child")
+		root.AddChild(child)
+	}
+	tree := NewTree([]*Node[string]{root}, WithProvider[string](&benchNodeProvider[string]{}))
+	ctx := context.Background()
+	tree.SetExpanded(ctx, "root", true)
+	return tree
+}
+
+// buildDeepTree creates a multi-level tree with branching factor per depth.
+func buildDeepTree(depth, branching int) *Tree[string] {
+	root := NewNode("root", "root", "root")
+	curLevel := []*Node[string]{root}
+	nodeCounter := 0
+	for d := 0; d < depth; d++ {
+		var next []*Node[string]
+		for _, parent := range curLevel {
+			for i := 0; i < branching; i++ {
+				id := fmt.Sprintf("d%dn%d_%d", d, i, nodeCounter)
+				nodeCounter++
+				child := NewNode(id, id, "n")
+				parent.AddChild(child)
+				next = append(next, child)
+			}
+		}
+		curLevel = next
+	}
+	tree := NewTree([]*Node[string]{root}, WithProvider[string](&benchNodeProvider[string]{}))
+	ctx := context.Background()
+	tree.ExpandAll(ctx)
+	return tree
+}
+
+var benchSink string // global sink to avoid compiler elimination
+
+func benchmarkRenderer(b *testing.B, fn func(context.Context, *Tree[string], *viewport.Model) (string, error), tree *Tree[string]) {
+	ctx := context.Background()
+	vp := viewport.New(100, 30)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vpcopy := vp // copy so offsets reset
+		s, err := fn(ctx, tree, &vpcopy)
+		if err != nil {
+			b.Fatalf("render error: %v", err)
+		}
+		benchSink = s
+	}
+}
+
+func BenchmarkRenderTreeWithViewport_Wide(b *testing.B) {
+	for _, n := range []int{1000, 5000, 10000} {
+		b.Run(fmt.Sprintf("%d", n), func(sb *testing.B) {
+			tree := buildWideTree(n)
+			benchmarkRenderer(sb, renderTreeWithViewport[string], tree)
+		})
+	}
+}
+
+func BenchmarkRenderTreeWithViewport_Deep(b *testing.B) {
+	cases := []struct{ depth, branching int }{{5, 3}, {6, 3}}
+	for _, c := range cases {
+		label := fmt.Sprintf("d%d_b%d", c.depth, c.branching)
+		b.Run(label, func(sb *testing.B) {
+			tree := buildDeepTree(c.depth, c.branching)
+			benchmarkRenderer(sb, renderTreeWithViewport[string], tree)
+		})
+	}
+}


### PR DESCRIPTION
This update represents a significant performance improvement for viewport aware rendering

```text
BenchmarkRenderTreeWithViewport_Wide/legacy_wide_1000-8                     1009           1272783 ns/op          472932 B/op       4101 allocs/op
BenchmarkRenderTreeWithViewport_Wide/legacy_wide_5000-8                      195           5916128 ns/op         1766394 B/op      20112 allocs/op
BenchmarkRenderTreeWithViewport_Wide/legacy_wide_10000-8                      87          12064861 ns/op         4191881 B/op      40121 allocs/op
BenchmarkRenderTreeWithViewport_Deep/legacy_d5_b3-8                         1860            615538 ns/op          319196 B/op       2121 allocs/op
BenchmarkRenderTreeWithViewport_Deep/legacy_d6_b3-8                          682           1695663 ns/op          690439 B/op       6499 allocs/op

BenchmarkRenderTreeWithViewport_Wide/1000-8                17308             67208 ns/op           81833 B/op        147 allocs/op
BenchmarkRenderTreeWithViewport_Wide/5000-8                 3894            299847 ns/op          602919 B/op        153 allocs/op
BenchmarkRenderTreeWithViewport_Wide/10000-8                1854            650096 ns/op         1157156 B/op        156 allocs/op
BenchmarkRenderTreeWithViewport_Deep/d5_b3-8               29205             41062 ns/op           18222 B/op        189 allocs/op
BenchmarkRenderTreeWithViewport_Deep/d6_b3-8               17007             70356 ns/op           31770 B/op        195 allocs/op
```