### PR TITLE
Fix focus falling outside the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.5.1] - 2025-08-17
+### Fixed
+- Fix focus node falling outside of viewport.
+
 ## [v1.5.0] - 2025-08-17
 ### Updated
 - Significantly improve render performance when using a viewport.


### PR DESCRIPTION
I accidentally introduced a bug in the last update that let the focus node fall outside the view port without scrolling. This fixes it.