### PR TITLE
Add progress callback option during tree construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.6.0] - 2025-08-19
+### Added
+- `WithProgressCallback` option for all constructors to report node build progress.
+
 ## [v1.5.1] - 2025-08-17
 ### Fixed
 - Fix focus node falling outside of viewport.

--- a/node.go
+++ b/node.go
@@ -167,7 +167,7 @@ func (n *Node[T]) Parent() *Node[T] {
 // need to juggle both pieces of information after a stat.
 type FileInfo struct {
 	os.FileInfo
-	Path string
+	Path  string
 	Extra map[string]any
 }
 

--- a/renderer.go
+++ b/renderer.go
@@ -115,7 +115,7 @@ func renderTree[T any](ctx context.Context, tree *Tree[T]) (string, int, error) 
 func renderTreeWithViewport[T any](ctx context.Context, tree *Tree[T], vp *viewport.Model) (string, error) {
 	// First, find the focused line position to determine if we need to adjust the viewport
 	focusedLineIndex := findFocusedLineIndex(ctx, tree)
-	
+
 	// Auto-scroll to keep focused line visible BEFORE rendering
 	if focusedLineIndex >= 0 && vp.Height > 0 {
 		// If focused line is above viewport, scroll up
@@ -128,14 +128,14 @@ func renderTreeWithViewport[T any](ctx context.Context, tree *Tree[T], vp *viewp
 			vp.YOffset = max(vp.YOffset, 0)
 		}
 	}
-	
+
 	// Now render only the visible portion with the correct viewport offset
 	content, totalLines, err := renderViewportOnly(ctx, tree, vp)
-	
+
 	// Update viewport's understanding of total content for scrollbar
 	// We use empty lines to set the height without the memory cost of actual content
 	vp.SetContent(strings.Repeat("\n", max(0, totalLines-1)))
-	
+
 	// Return just the visible content
 	return content, err
 }
@@ -152,7 +152,7 @@ func findFocusedLineIndex[T any](ctx context.Context, tree *Tree[T]) int {
 			return lineIdx
 		}
 		lineIdx++
-		
+
 		// Check for context cancellation periodically
 		if lineIdx%100 == 0 {
 			if ctx.Err() != nil {
@@ -176,11 +176,11 @@ func renderViewportOnly[T any](ctx context.Context, tree *Tree[T], vp *viewport.
 	// Calculate the range of lines we need to render
 	startLine := vp.YOffset
 	endLine := vp.YOffset + vp.Height
-	
+
 	// Track state for single-pass rendering
 	currentLine := 0
 	renderBuffer := make([]string, 0, vp.Height) // Pre-allocate for viewport height
-	
+
 	// ancestorIsLastChild tracks whether each ancestor (at each depth level) was the last
 	// child among its siblings. This determines whether we draw a vertical continuation
 	// line (│) or a space when building the tree prefix.
@@ -190,7 +190,7 @@ func renderViewportOnly[T any](ctx context.Context, tree *Tree[T], vp *viewport.
 		if err != nil {
 			return "", currentLine, err
 		}
-		
+
 		node := info.Node
 		depth := info.Depth
 		isLast := info.IsLast

--- a/tree.go
+++ b/tree.go
@@ -25,8 +25,8 @@ import (
 // filtering, searching, focusing, and rendering. All public methods are safe
 // for concurrent use; a sync.RWMutex guards internal state.
 type Tree[T any] struct {
-	mu      sync.RWMutex
-	nodes   []*Node[T]
+	mu           sync.RWMutex
+	nodes        []*Node[T]
 	focusedNodes []*Node[T]
 	focusedIDs   map[string]bool
 
@@ -333,7 +333,7 @@ func (t *Tree[T]) setVisibleState(ctx context.Context, visible bool) error {
 func (t *Tree[T]) GetAllFocusedIDs() []string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	
+
 	ids := make([]string, len(t.focusedNodes))
 	for i, node := range t.focusedNodes {
 		ids[i] = node.ID()
@@ -345,7 +345,7 @@ func (t *Tree[T]) GetAllFocusedIDs() []string {
 func (t *Tree[T]) GetAllFocusedNodes() []*Node[T] {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	
+
 	// Return a copy to prevent external modification
 	nodes := make([]*Node[T], len(t.focusedNodes))
 	copy(nodes, t.focusedNodes)


### PR DESCRIPTION
This will allow consumers to create loading bars during tree construction. 