### PR TITLE
Add set nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.7.0] - 2025-08-19
+### Added
+- `SetNodes` option for tree to allow updates to root nodes without full tree reconstruction.
+
 ## [v1.6.0] - 2025-08-19
 ### Added
 - `WithProgressCallback` option for all constructors to report node build progress.

--- a/tree.go
+++ b/tree.go
@@ -43,6 +43,14 @@ func (t *Tree[T]) Nodes() []*Node[T] {
 	return t.nodes
 }
 
+// SetNodes replaces the root nodes of the tree. This is useful for removing
+// root nodes or restructuring the tree. The operation is thread-safe.
+func (t *Tree[T]) SetNodes(nodes []*Node[T]) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.nodes = nodes
+}
+
 // GetFocusedID returns the ID of the currently focused node or "" if none.
 func (t *Tree[T]) GetFocusedID() string {
 	t.mu.RLock()


### PR DESCRIPTION
## [v1.7.0] - 2025-08-19
### Added
- `SetNodes` option for tree to allow updates to root nodes without full tree reconstruction.
